### PR TITLE
Fix example config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Example:
     "initialized": false,
     "options": {
         "minify": { },
-        "beautify": { }
-    },
-    "pluginOptions": {
-        "verbose": false
+        "beautify": { },
+        "pluginOptions": {
+            "verbose": false
+        }
     }
 }
 ```


### PR DESCRIPTION
The plugin is expecting the `pluginOptions` object to be inside `plugin-node-minify-html.options` and not on root plugin config level at `plugin-node-minify-html.pluginOptions`

This brings the docs in line with:

```
    let options = patternlab.config.plugins[pluginName].options;
    let pluginOptions = options.pluginOptions;
```