### PR TITLE
fix: plugin doesn't work with the current version of PL 3.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,8 +17,9 @@ function writeConfigToOutput(patternlab, pluginConfig) {
     }
 }
 
-function onPatternIterate(patternlab, pattern) {
-    pattern_minify(patternlab, pattern);
+async function onPatternIterate(params) {
+    const [patternlab, pattern] = params;
+    await pattern_minify(patternlab, pattern);
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,39 +1,39 @@
 {
-    "name": "plugin-node-minify-html",
-    "version": "1.0.7",
-    "description": "The Minify HTML Plugin allows [Pattern Lab Node](https://github.com/pattern-lab/patternlab-node) users to minify and beautify the HTML template of all patterns. If the right options are passed, HTML errors like empty attributes can be prevented (id=\"\" and class=\"\") and the production code size can be reduced.",
-    "main": "index.js",
-    "dependencies": {
-        "fs-extra": "^7.0.1",
-        "glob": "^7.1.3",
-        "html-minifier": "^3.5.21",
-        "js-beautify": "^1.8.9"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/SlimeGames/plugin-node-minify-html.git"
-    },
-    "scripts": {
-        "test": "eslint src/** index.js postinstall.js",
-        "postinstall": "node ./postinstall.js"
-    },
-    "author": "Josef Bredereck",
-    "license": "MIT",
-    "bugs": {
-        "url": "https://github.com/SlimeGames/plugin-node-minify-html/issues"
-    },
-    "homepage": "https://github.com/SlimeGames/plugin-node-minify-html",
-    "devDependencies": {
-        "eslint": "^6.4.0"
-    },
-    "keywords": [
-        "Patternlab",
-        "node",
-        "plugin",
-        "html",
-        "beautify",
-        "minify",
-        "js-beautify",
-        "html-minifier"
-    ]
+  "name": "plugin-node-minify-html",
+  "version": "1.0.8",
+  "description": "The Minify HTML Plugin allows [Pattern Lab Node](https://github.com/pattern-lab/patternlab-node) users to minify and beautify the HTML template of all patterns. If the right options are passed, HTML errors like empty attributes can be prevented (id=\"\" and class=\"\") and the production code size can be reduced.",
+  "main": "index.js",
+  "dependencies": {
+    "fs-extra": "^7.0.1",
+    "glob": "^7.1.3",
+    "html-minifier": "^3.5.21",
+    "js-beautify": "^1.8.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/SlimeGames/plugin-node-minify-html.git"
+  },
+  "scripts": {
+    "test": "eslint src/** index.js postinstall.js",
+    "postinstall": "node ./postinstall.js"
+  },
+  "author": "Josef Bredereck",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/SlimeGames/plugin-node-minify-html/issues"
+  },
+  "homepage": "https://github.com/SlimeGames/plugin-node-minify-html",
+  "devDependencies": {
+    "eslint": "^6.4.0"
+  },
+  "keywords": [
+    "Patternlab",
+    "node",
+    "plugin",
+    "html",
+    "beautify",
+    "minify",
+    "js-beautify",
+    "html-minifier"
+  ]
 }


### PR DESCRIPTION
error on console: "plugin-node-minify-html: pattern object not provided"

I am using Pattern Lab Node `v5.10.1` on Mac OS, with Node `v13.12.0`, using `@pattern-lab/edition-node` Edition.